### PR TITLE
Removed bugs and try catch blocks

### DIFF
--- a/Tools/SeeDot/SeeDot-dev.py
+++ b/Tools/SeeDot/SeeDot-dev.py
@@ -231,10 +231,9 @@ class MainDriver:
             obj = main.Main(algo, version, target, trainingInput,
                             testingInput, modelDir, sf, maximisingMetric, dataset)
             obj.run()
-            try:
-                acc = obj.testingAccuracy
-            except:
-                print("CODE FAILED TO COMPILE AND/OR EXECUTE")
+
+            acc = obj.testingAccuracy
+
             if acc != expectedAcc:
                 print("FAIL: Expected accuracy %f%%" % (expectedAcc))
                 # return

--- a/Tools/SeeDot/seedot/compiler/codegen/x86.py
+++ b/Tools/SeeDot/seedot/compiler/codegen/x86.py
@@ -63,7 +63,7 @@ class X86(CodegenBase):
 
             self.printExpTables()
 
-            self.printVarDecls()
+            # self.printVarDecls()
 
         self.printCHeader()
 
@@ -191,8 +191,7 @@ class X86(CodegenBase):
                 shape_str = ''.join(['[' + str(n) + ']' for n in type.shape])
 
             if not config.vbwEnabled:
-                self.out.printf('%s vars_%s::%s%s;\n', typ_str,
-                                getVersion(), idf_str, shape_str, indent=True)
+                self.out.printf('%s %s%s;\n', typ_str, idf_str, shape_str, indent=True)
                 if self.generateAllFiles:
                     varsFile.printf('extern %s %s%s;\n', typ_str,
                                 idf_str, shape_str, indent=True)

--- a/Tools/SeeDot/seedot/compiler/ir/irBuilder.py
+++ b/Tools/SeeDot/seedot/compiler/ir/irBuilder.py
@@ -1513,7 +1513,7 @@ class IRBuilder(ASTVisitor):
         elif node.op == SeeDotParser.SGN:
             return self.visitSgn(node)
         elif node.op == SeeDotParser.TANH:
-            if useNewTableExp() and forFixed():
+            if useNewTableExp() and forFixed() and self.vbwEnabled:
                 return self.visitNewTableTanH(node)
             else:
                 return self.visitTanh(node)

--- a/Tools/SeeDot/seedot/main.py
+++ b/Tools/SeeDot/seedot/main.py
@@ -78,21 +78,16 @@ class Main:
         elif target == config.Target.x86:
             outputDir = os.path.join(config.tempdir, "Predictor")
 
-        try:
-            obj = Compiler(self.algo, version, target, inputFile, outputDir,
-                           profileLogFile, sf, outputLogFile, 
-                           generateAllFiles, id, printSwitch, self.variableSubstitutions, 
-                           scaleForX,
-                           variableToBitwidthMap, self.sparseMatrixSizes, demotedVarsList, demotedVarsOffsets)
-            obj.run()
-            self.allScales = dict(obj.varScales)
-            if version == config.Version.floatt:
-                self.variableSubstitutions = obj.substitutions
-                self.variableToBitwidthMap = dict.fromkeys(obj.independentVars, config.wordLength)
-        except:
-            print("failed!\n")
-            #traceback.print_exc()
-            return False
+        obj = Compiler(self.algo, version, target, inputFile, outputDir,
+                        profileLogFile, sf, outputLogFile, 
+                        generateAllFiles, id, printSwitch, self.variableSubstitutions, 
+                        scaleForX,
+                        variableToBitwidthMap, self.sparseMatrixSizes, demotedVarsList, demotedVarsOffsets)
+        obj.run()
+        self.allScales = dict(obj.varScales)
+        if version == config.Version.floatt:
+            self.variableSubstitutions = obj.substitutions
+            self.variableToBitwidthMap = dict.fromkeys(obj.independentVars, config.wordLength)
 
         if id is None:
             self.scaleForX = obj.scaleForX
@@ -228,10 +223,13 @@ class Main:
                 if highestValidScale == end:
                     print("Compilation not possible for any Scale Factor. Abort")
                     return False
+                
+                # Refactor and remove this try/catch block in the futur 
                 try:
                     firstCompileSuccess = self.partialCompile(config.Version.fixed, config.Target.x86, highestValidScale, True, None, 0, dict(self.variableToBitwidthMap), list(self.demotedVarsList), dict(self.demotedVarsOffsets))
-                except:
+                except:	
                     firstCompileSuccess = False
+
                 if firstCompileSuccess:
                     break
                 highestValidScale -= 1


### PR DESCRIPTION
2 bugs
1. Not printing global variables
2. `newTanhTable` should be called only when `vbw` is enabled

Removed `try/catch` blocks. The code should fail wherever it fails and return the correct spot of error unless there is some backup for the failed code.  